### PR TITLE
Fix incorrect generation of iat in jwt

### DIFF
--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -6,7 +6,7 @@ const generateJWT = (schemeId, jwtSecret) => {
     return jwt.sign(
         {
             aud: schemeId,
-            iat: Math.floor(Date.now / 1000),
+            iat: Math.floor(Date.now() / 1000),
             jti: uuid.v4()
         },
         jwtSecret


### PR DESCRIPTION
in `src/helpers/auth.js`, you have a helper function to generate the `iat` which indicates the age of the jwt.

    iat: Math.floor(Date.now / 1000),

will always give

     Nan

It should have been

    iat: Math.floor(Date.now() / 1000),   //notice the corrected braces after Date.now

Your API infact seems to only accept incorrect iat.

when we pass a valid iat on prod - we get the error

    Token used before issue

This error and validation did not happen on staging