### PR TITLE
Support for adding custom transaction note on create payment link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ let paymentLinkBody = {
     payeeName: String, // Optional
     expiryDate: String, // Optional
     settlement: Object, // Optional
-    validationRules: Object // Optional
+    validationRules: Object, // Optional
+    transactionNote: String // Optional
 };
 
 let data = await setu.createPaymentLink(paymentLinkBody);

--- a/src/helpers/body.js
+++ b/src/helpers/body.js
@@ -11,7 +11,8 @@ bodyHelper.createPaymentLink = ({
     expiryDate,
     amountExactness,
     settlement,
-    validationRules
+    validationRules,
+    transactionNote,
 }) => {
     let body = {
         amount: {
@@ -27,7 +28,7 @@ bodyHelper.createPaymentLink = ({
     body = commonHelper.addIfExists('payeeName', payeeName, body);
     body = commonHelper.addIfExists('settlement', settlement, body);
     body = commonHelper.addIfExists('validationRules', validationRules, body);
-
+    body = commonHelper.addIfExists('transactionNote', transactionNote, body);
     return body;
 };
 


### PR DESCRIPTION
Now you can add a custom transaction note message while creating payment link if blank default will be added. 