### PR TITLE
feat(api)!: move to generic refund status API

### DIFF
--- a/src/lib/deeplinks.spec.ts
+++ b/src/lib/deeplinks.spec.ts
@@ -139,6 +139,15 @@ test("Make payment for DL and initiate refund", async (t) => {
     const getRefundBatchStatusResponse = await upiDL.getRefundBatchStatus(initiateRefundResponse.batchID);
     t.is(getRefundBatchStatusResponse.refunds[0].billID, platformBillID);
 
+    const getRefundStatusByBatchResponse = await upiDL.getRefundStatusByIdentifier(
+        "batch",
+        initiateRefundResponse.batchID
+    );
+    t.is(getRefundStatusByBatchResponse.refunds[0].billID, platformBillID);
+
+    const getRefundStatusByBillResponse = await upiDL.getRefundStatusByIdentifier("bill", platformBillID);
+    t.is(getRefundStatusByBillResponse.refunds[0].status, "Created");
+
     const getRefundStatusResponse = await upiDL.getRefundStatus(getRefundBatchStatusResponse.refunds[0].id);
     t.is(getRefundStatusResponse.billID, platformBillID);
 

--- a/src/lib/deeplinks.ts
+++ b/src/lib/deeplinks.ts
@@ -17,6 +17,7 @@ import {
 import {
     CreatePaymentLinkParams,
     InitiateRefundParams,
+    RefundStatusIdentifierType,
     SetuError,
     SetuUPIDeepLinkInstance,
     TriggerMockPaymentParams,
@@ -72,10 +73,27 @@ export const SetuUPIDeepLink = (params: SetuUPIDeepLinkParams): SetuUPIDeepLinkI
         }
     };
 
+    /**
+     * @deprecated This method is replaced by {@link getRefundStatusByIdentifier}
+     */
     const getRefundBatchStatus = async (batchID: string): Promise<BatchRefundStatusResponseData> => {
         try {
             const { data: response } = await collectAxiosInstance.get<SetuResponseBase<BatchRefundStatusResponseData>>(
                 `${getURLPath(params.mode, params.authType, API.REFUND_BASE)}/batch/${batchID}`
+            );
+            return response.data;
+        } catch (err) {
+            return setuErrorHandler(err as AxiosError<SetuResponseBase<unknown>>);
+        }
+    };
+
+    const getRefundStatusByIdentifier = async (
+        identifierType: RefundStatusIdentifierType,
+        identifierValue: string
+    ): Promise<BatchRefundStatusResponseData> => {
+        try {
+            const { data: response } = await collectAxiosInstance.get<SetuResponseBase<BatchRefundStatusResponseData>>(
+                `${getURLPath(params.mode, params.authType, API.REFUND_BASE)}/${identifierType}/${identifierValue}`
             );
             return response.data;
         } catch (err) {
@@ -118,6 +136,7 @@ export const SetuUPIDeepLink = (params: SetuUPIDeepLinkParams): SetuUPIDeepLinkI
         expireBill,
         initiateRefund,
         getRefundBatchStatus,
+        getRefundStatusByIdentifier,
         getRefundStatus,
         triggerMockPayment,
         isSetuError,

--- a/src/lib/helpers/types.ts
+++ b/src/lib/helpers/types.ts
@@ -227,6 +227,5 @@ type RefundResponseDataItem =
       } & RefundResponseErrorData);
 
 export type BatchRefundStatusResponseData = {
-    readonly batchID: string;
     readonly refunds: readonly RefundResponseSuccessData[];
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,8 @@ type RefundRequest = InitiateRefundAmountParams & {
     readonly deductions?: readonly Deduction[];
 };
 
+export type RefundStatusIdentifierType = "batch" | "bill";
+
 /* Global */
 export type SetuUPIDeepLinkInstance = {
     readonly createPaymentLink: (body: CreatePaymentLinkParams) => Promise<CreatePaymentLinkResponseData>;
@@ -53,6 +55,10 @@ export type SetuUPIDeepLinkInstance = {
     readonly expireBill: (platformBillID: string) => Promise<void>;
     readonly initiateRefund: (body: InitiateRefundParams) => Promise<InitiateRefundResponseData>;
     readonly getRefundBatchStatus: (batchID: string) => Promise<BatchRefundStatusResponseData>;
+    readonly getRefundStatusByIdentifier: (
+        identifierType: RefundStatusIdentifierType,
+        identifierValue: string
+    ) => Promise<BatchRefundStatusResponseData>;
     readonly getRefundStatus: (refundID: string) => Promise<RefundResponseSuccessData>;
     readonly triggerMockPayment: (body: TriggerMockPaymentParams) => Promise<TriggerMockPaymentResponseData>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
The refund batch status API is at path `GET /refund/batch/{batchID}`,
which while continuing to work, will no longer return `batchID` as
part of the response. This allows the internal API to be more generic,
supporting fetching the refund status by more identifiers.

The path for the internal API has now changed to:
`GET /refund/{identifierType}/{identifierValue}`

The allowed values for `identifierType` at this point are:
- batch
- bill

If you were not using the `batchID` in the response in your code,
then your integration will continue to work. In either case, the
`getRefundBatchStatus` is deprecated and it is recommended to use
the new `getRefundStatusByIdentifier` method instead.
